### PR TITLE
no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ keywords = ["svf", "audio", "dsp", "filter"]
 [dependencies]
 num-traits = "0.2"
 num-complex = "0.4"
-thiserror = "1.0"
+thiserror = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "State Variable Filters for real-time audio in pure Rust"
 readme = "README.md"
 homepage = "https://neodsp.com/"
 repository = "https://github.com/neodsp/simper-filter/"
-categories = ["multimedia::audio"]
+categories = ["no-std", "multimedia::audio"]
 license = "MIT OR Apache-2.0"
 keywords = ["svf", "audio", "dsp", "filter"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
+#![cfg_attr(not(test), no_std)]
+
+use core::f64::consts::{PI, TAU};
 use num_complex::Complex64;
 use num_traits::Float;
-use std::f64::consts::{PI, TAU};
 use thiserror::Error;
 
 #[derive(Error, Debug)]


### PR DESCRIPTION
This PR applies some minor changes to make the crate `no_std` so it can be used in embedded environments.